### PR TITLE
Makes the `Web::getECDSACryptoKey` method public

### DIFF
--- a/src/Adapter/Web.php
+++ b/src/Adapter/Web.php
@@ -271,7 +271,7 @@ class Web extends BaseAdapter
      * Get the ECDSA public key encoded by the URL- and filename-safe variant of
      * base-64 [RFC4648] with padding removed.
      */
-    protected function getECDSACryptoKey()
+    public function getECDSACryptoKey()
     {
         return Base64Url::encode(PublicKeyUtil::getKeyFromPem($this->getParameter('publicKey')));
     }


### PR DESCRIPTION
Making this method public means we don't have to calculate it separately
when we need to display it elsewhere.